### PR TITLE
(SIMP-2670) Update invalid dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,9 +1,9 @@
 # Drop all Requires, Obsoletes, and Provides statements in here
-Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
-Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
-Requires: pupmod-simp-simplib >= 3.1.0-0
-Requires: pupmod-simp-simplib < 4.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_core < 3.0.0-0
-Requires: pupmod-herculesteam-augeasproviders_core >= 2.1.0-0
+Requires: pupmod-herculesteam-augeasproviders_core >= 2.1.3-0
 Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
+Requires: pupmod-simp-simplib < 4.0.0-0
+Requires: pupmod-simp-simplib >= 3.2.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,17 +1,19 @@
 {
-  "name":    "simp-swap",
+  "name": "simp-swap",
   "version": "0.1.0",
-  "author":  "SIMP Team",
+  "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing swappiness",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-swap",
+  "source": "https://github.com/simp/pupmod-simp-swap",
   "project_page": "https://github.com/simp/pupmod-simp-swap",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp"
+  ],
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">= 2.1.1 < 3.0.0"
+      "version_requirement": ">= 2.1.3 < 3.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",
@@ -19,11 +21,11 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 3.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` referred to old
versions that would be invalid in SIMP 6.0.0.

This commit resolves the issue by updating the upper and lower
boundaries for each dependency in `metadata.json` and RPM `requires` to
reflect the versions found in SIMP-6.0.0.

SIMP-2670 #comment Fixed `pupmod-simp-swap`