### PR TITLE
(Simp 6426) Updated ruby location in dynamic_swappiness.erb

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Apr 07 2019 Jim Anderson <thesemicolons@protonmail.com> - 0.1.4-0
+- Changed location of ruby in dynamic_swappiness.erb to point to the
+  SIMP provided version instead of an OS provided version.
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.3-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Wed Apr 17 2019 Jim Anderson <thesemicolons@protonmail.com> - 0.1.4-0
 - Changed location of ruby in dynamic_swappiness.erb to point to the
   SIMP provided version instead of an OS provided version.
+- Updated expected templates in Travis CI checks.
 
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.3-0
 - Update the upper bound of stdlib to < 6.0.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Apr 07 2019 Jim Anderson <thesemicolons@protonmail.com> - 0.1.4-0
+* Wed Apr 17 2019 Jim Anderson <thesemicolons@protonmail.com> - 0.1.4-0
 - Changed location of ruby in dynamic_swappiness.erb to point to the
   SIMP provided version instead of an OS provided version.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-swap",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing swappiness",
   "license": "Apache-2.0",

--- a/spec/expected/dynamic_swappiness.rb
+++ b/spec/expected/dynamic_swappiness.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/opt/puppetlabs/puppet/bin/ruby
 
 require 'optparse'
 

--- a/spec/expected/dynamic_swappiness_off_default.rb
+++ b/spec/expected/dynamic_swappiness_off_default.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/opt/puppetlabs/puppet/bin/ruby
 
 require 'optparse'
 

--- a/templates/dynamic_swappiness.erb
+++ b/templates/dynamic_swappiness.erb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/opt/puppetlabs/puppet/bin/ruby
 
 require 'optparse'
 


### PR DESCRIPTION
Changed location of ruby in dynamic_swappiness.erb to point to the SIMP
provided version instead of an OS provided version. Also updated checks
for Travis CI so they will pass.